### PR TITLE
Bugfix for set block 3 (CRC), add debug log

### DIFF
--- a/ckermit-config.txt
+++ b/ckermit-config.txt
@@ -1,5 +1,11 @@
 set port /dev/cu.usbserial-DK0FK4MK
 set baud 9600
 set carrier-watch off
+# Set safe side configs
 robust
+# CRC is not supported
 set block 1
+# This works OK
+set prefixing minimal
+# This is required to avoid type conversion
+set file type binary

--- a/ckermit-config.txt
+++ b/ckermit-config.txt
@@ -1,10 +1,8 @@
 set port /dev/cu.usbserial-DK0FK4MK
 set baud 9600
 set carrier-watch off
-# Set safe side configs
-robust
-# CRC is not supported
-set block 1
+# No streaming
+set streaming off
 # This works OK
 set prefixing minimal
 # This is required to avoid type conversion

--- a/kermit.h
+++ b/kermit.h
@@ -67,7 +67,7 @@
 #ifdef NEO6502
 #define NO_SCAN /* We don't need F_SCAN, transparent file only */
 #define FN_MAX 16
-#define P_PKTLEN 256
+#define P_PKTLEN 512
 #endif /* NEO6502 */
 
 /* XAC compiler for Philips XAG30 microprocessor */

--- a/kermit.h
+++ b/kermit.h
@@ -68,11 +68,10 @@
 #define NO_LP /* No long packets */
 #define NO_SSW
 #define NO_SCAN /* We don't need F_SCAN, transparent file only */
-// TODO: block type 3 doesn't work
-#define NO_CRC
 #define FN_MAX 16
-#define IBUFLEN 128
-#define OBUFLEN 512
+#define P_PKTLEN 100 // This should include block checksums!
+#define IBUFLEN 256
+#define OBUFLEN 1024
 #endif /* NEO6502 */
 
 /* XAC compiler for Philips XAG30 microprocessor */

--- a/kermit.h
+++ b/kermit.h
@@ -65,13 +65,9 @@
 #define NEO6502
 
 #ifdef NEO6502
-#define NO_LP /* No long packets */
-#define NO_SSW
 #define NO_SCAN /* We don't need F_SCAN, transparent file only */
 #define FN_MAX 16
-#define P_PKTLEN 100 // This should include block checksums!
-#define IBUFLEN 256
-#define OBUFLEN 1024
+#define P_PKTLEN 256
 #endif /* NEO6502 */
 
 /* XAC compiler for Philips XAG30 microprocessor */
@@ -217,7 +213,12 @@
 #ifdef F_LP
 #define P_PKTLEN 4096
 #else
+#ifdef F_CRC
+// add 2 bytes to accomodate block check type 3
+#define P_PKTLEN 96
+#else
 #define P_PKTLEN 94
+#endif /* F_CRC */
 #endif /* F_LP */
 #endif /* P_PKTLEN */
 

--- a/main.c
+++ b/main.c
@@ -222,7 +222,8 @@ int main(int argc, char **argv) {
     }
     /* Handle the input */
 
-    switch (status = kermit(K_RUN, &k, r_slot, rx_len, "", &r)) {
+    status = kermit(K_RUN, &k, r_slot, rx_len, "", &r);
+    switch (status) {
     case X_OK:
 #ifdef DEBUG
       /*
@@ -244,11 +245,12 @@ int main(int argc, char **argv) {
       debug(DB_LOG, "SOFAR", 0, r.sofar);
 #endif /* DEBUG */
       /* Maybe do other brief tasks here... */
-      continue; /* Keep looping */
+      break; /* Exit the switch statement and keep looping */
     case X_DONE:
       break; /* Finished */
     case X_ERROR:
       doexit(FAILURE); /* Failed */
+      // NOTREACHABLE
     }
   }
   doexit(SUCCESS);

--- a/neoio.c
+++ b/neoio.c
@@ -38,6 +38,7 @@
 
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <neo/api.h>
 
@@ -54,10 +55,27 @@ UCHAR i_buf[IBUFLEN + 8];
 #define CHANNEL_OUTPUT_FILE (2)
 
 // Debugging functions
-// TODO: Can output be a file?
+// Output written simultaneoutly to
+// Neo Console and file "KDEBUG.LOG"
 
 #ifdef DEBUG
+
+#define CHANNEL_DEBUG_OUTPUT (3)
+#define DBUFLEN (256)
+#define DEBUG_FILE "KDEBUG.LOG"
+
 static int xdebug = 0; /* Debugging on/off */
+static uint8_t dchannel = CHANNEL_DEBUG_OUTPUT;
+
+static char dbuf[DBUFLEN];
+
+void debugout(char *str) {
+  (void)neo_file_write(dchannel, str, strlen(str));
+  while (*str != '\0') {
+    putchar((int)*str);
+    str++;
+  }
+}
 
 void dodebug(int fc, UCHAR *label, UCHAR *sval, long nval) {
   if (fc != DB_OPN && !xdebug) {
@@ -69,25 +87,34 @@ void dodebug(int fc, UCHAR *label, UCHAR *sval, long nval) {
   switch (fc) { /* Function code */
   case DB_OPN:  /* Open debug log */
     xdebug = 1;
-    printf("DEBUG LOG OPEN\n");
+    neo_file_open(dchannel, (const char *)DEBUG_FILE,
+                  3); // truncate and read-write
+    snprintf(dbuf, DBUFLEN, "DEBUG LOG OPEN\n");
+    debugout(dbuf);
     return;
   case DB_MSG: /* Write a message */
-    printf("%s\n", label);
+    snprintf(dbuf, DBUFLEN, "%s\n", label);
+    debugout(dbuf);
     return;
   case DB_CHR: /* Write label and character */
-    printf("%s=[%c]\n", label, (char)nval);
+    snprintf(dbuf, DBUFLEN, "%s=[%c]\n", label, (char)nval);
+    debugout(dbuf);
     return;
   case DB_PKT: /* Log a packet */
                /* (fill in later, fall thru for now...) */
   case DB_LOG: /* Write label and string or number */
     if (sval) {
-      printf("%s[%s]\n", label, sval);
+      snprintf(dbuf, DBUFLEN, "%s[%s]\n", label, sval);
+      debugout(dbuf);
     } else {
-      printf("%s=%ld\n", label, nval);
+      snprintf(dbuf, DBUFLEN, "%s=%ld\n", label, nval);
+      debugout(dbuf);
     }
     return;
   case DB_CLS: /* Close debug log */
     xdebug = 0;
+    neo_file_close(dchannel);
+    return;
   }
 }
 #endif /* DEBUG */

--- a/neoio.c
+++ b/neoio.c
@@ -148,7 +148,7 @@ void devinit(void) {
 //
 // Timeout not implemented in this sample.
 
-int readpkt(struct k_data *k, UCHAR *p, int len, int fc) {
+int readpkt(struct k_data *k, UCHAR *p, int len) {
   int x, n, max;
   short flag;
   UCHAR c;

--- a/neoio.c
+++ b/neoio.c
@@ -147,6 +147,7 @@ void devinit(void) {
 //   -1   - fatal error, such as loss of connection, or no buffer to read into.
 //
 // Timeout not implemented in this sample.
+// Maximum packet length to receive: k->r_maxlen
 
 int readpkt(struct k_data *k, UCHAR *p, int len) {
   int x, n, max;
@@ -209,7 +210,9 @@ int readpkt(struct k_data *k, UCHAR *p, int len) {
       return (n);
     } else {                   /* Contents of packet */
       if (n++ > k->r_maxlen) { /* Check length */
-        return (0);
+        // Too long packet is not correctable
+        debug(DB_MSG, "readpkt packet too long", 0, 0);
+        return (-1);
       } else {
         *p++ = x & 0xff;
       }

--- a/neoio.c
+++ b/neoio.c
@@ -112,6 +112,8 @@ void dodebug(int fc, UCHAR *label, UCHAR *sval, long nval) {
     }
     return;
   case DB_CLS: /* Close debug log */
+    snprintf(dbuf, DBUFLEN, "DEBUG LOG CLOSE\n");
+    debugout(dbuf);
     xdebug = 0;
     neo_file_close(dchannel);
     return;


### PR DESCRIPTION
* P_PKTLEN must be set to 96 to accommodate 3-byte checksum packets
* Add debug log to file "KDEBUG.LOG"
* Set P_PKTLEN to 512, long packet is OK, CRC (block type 3) is OK